### PR TITLE
Allow more than just octave 3 when creating scales

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ musical_scales.scale("D")
 musical_scales.scale("F#", "blues")
 # [F#3, A3, B3, C4, C#4, E4, F#4]
 musical_scales.scale("D", starting_octave=5)
-# Defaults to major scale
 # [D5, E5, F#5, G5, A5, B5, C#6, D6]
 ````
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ musical_scales.scale("D")
 # [D3, E3, F#3, G3, A3, B3, C#4, D4]
 musical_scales.scale("F#", "blues")
 # [F#3, A3, B3, C4, C#4, E4, F#4]
+musical_scales.scale("D", starting_octave=5)
+# Defaults to major scale
+# [D5, E5, F#5, G5, A5, B5, C#6, D6]
 ````
 
 

--- a/src/musical_scales/__init__.py
+++ b/src/musical_scales/__init__.py
@@ -62,7 +62,7 @@ class Note:
 
     def __add__(self, shift: int):
         """Shifting this note's degree upwards."""
-        return Note(semitones_above_middle_c=self.semitones_above_middle_c, starting_octave=self.starting_octave + shift)
+        return Note(semitones_above_middle_c=self.semitones_above_middle_c + shift, starting_octave=self.starting_octave)
 
     def __sub__(self, shift: int):
         """Shifting this note's degree downwards."""

--- a/src/musical_scales/__init__.py
+++ b/src/musical_scales/__init__.py
@@ -21,13 +21,14 @@ class Note:
     name: str
     octave: int
 
-    def __init__(self, name: str = None, semitones_above_middle_c: int = None):
+    def __init__(self, name: str = None, semitones_above_middle_c: int = None, starting_octave: int = 3):
         """Create a note with a given name or degree.
 
         Examples:
             * Note("C#")
             * Note(semitones_above_middle_c = 1)
         """
+        self.starting_octave = starting_octave
         if name is not None:
             if name not in interval_from_names:
                 raise MusicException(f"No note found with name {name}.")
@@ -44,7 +45,7 @@ class Note:
         """
         self.semitones_above_middle_c = semitones_above_middle_c
         self.name = names_from_interval[semitones_above_middle_c % 12]
-        self.octave = math.floor(semitones_above_middle_c / 12) + 3
+        self.octave = math.floor(semitones_above_middle_c / 12) + self.starting_octave
 
     def __str__(self):
         """MIDI-style string representation e.g. C#3."""
@@ -61,7 +62,7 @@ class Note:
 
     def __add__(self, shift: int):
         """Shifting this note's degree upwards."""
-        return Note(semitones_above_middle_c=self.semitones_above_middle_c + shift)
+        return Note(semitones_above_middle_c=self.semitones_above_middle_c + shift, starting_octave=self.starting_octave)
 
     def __sub__(self, shift: int):
         """Shifting this note's degree downwards."""
@@ -75,7 +76,7 @@ class Note:
             return self.midi == other or self.name == other
 
 
-def scale(starting_note, mode="ionian", octaves=1):
+def scale(starting_note, starting_octave=3, mode="ionian", octaves=1):
     """Return a sequence of Notes starting on the given note in the given mode.
 
     Example:
@@ -85,7 +86,7 @@ def scale(starting_note, mode="ionian", octaves=1):
     if mode not in scale_intervals:
         raise MusicException(f"The mode {mode} is not available.")
     if not isinstance(starting_note, Note):
-        starting_note = Note(starting_note)
+        starting_note = Note(starting_note, starting_octave=starting_octave)
     notes = [starting_note]
     for octave in range(0, octaves):
         for interval in scale_intervals[mode]:

--- a/src/musical_scales/__init__.py
+++ b/src/musical_scales/__init__.py
@@ -76,7 +76,7 @@ class Note:
             return self.midi == other or self.name == other
 
 
-def scale(starting_note, starting_octave=3, mode="ionian", octaves=1):
+def scale(starting_note, mode="ionian", octaves=1, starting_octave=3):
     """Return a sequence of Notes starting on the given note in the given mode.
 
     Example:

--- a/src/musical_scales/__init__.py
+++ b/src/musical_scales/__init__.py
@@ -62,7 +62,7 @@ class Note:
 
     def __add__(self, shift: int):
         """Shifting this note's degree upwards."""
-        return Note(semitones_above_middle_c=self.semitones_above_middle_c + shift, starting_octave=self.starting_octave)
+        return Note(semitones_above_middle_c=self.semitones_above_middle_c, starting_octave=self.starting_octave + shift)
 
     def __sub__(self, shift: int):
         """Shifting this note's degree downwards."""

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -6,11 +6,14 @@ import pytest
 def test_middle_c():
     """Test creation of C3."""
     c_3 = musical_scales.Note("C")
+    assert c_3.octave == 3
     assert c_3.name == "C"
     d_3 = c_3+2
     assert d_3.name == "D"
     b_2 = c_3 -1
     assert b_2.name == "B"
+    c_5 = musical_scales.Note("C", starting_octave=5)
+    assert c_5.octave == 5
 
 def test_equality():
     """Notes should compare permissively."""

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -1,5 +1,8 @@
 """Test the creation of scales."""
 
+# import sys
+# sys.path.append('./src')
+# import musical_scales.musical_scales
 import musical_scales
 import pytest
 
@@ -9,6 +12,12 @@ def test_ionian():
     scale_notes = musical_scales.scale("D")
     names = list(map(lambda note: note.midi, scale_notes))
     assert names == ["D3", "E3", "F#3", "G3", "A3", "B3", "C#4", "D4"]
+
+def test_octave():
+    """Check that C major with given octave is correct."""
+    scale_notes = musical_scales.scale("D", octave=5)
+    names = list(map(lambda note: note.midi, scale_notes))
+    assert names == ["C5", "D5", "E5", "F5", "G5", "A5", "B5", "C6"]
 
 def test_octaves():
     """Check that D major is correct with 2 octaves."""

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -1,8 +1,9 @@
 """Test the creation of scales."""
 
-# import sys
-# sys.path.append('./src')
-# import musical_scales.musical_scales
+import sys
+from pathlib import Path
+sys.path.append('./src')
+
 import musical_scales
 import pytest
 
@@ -17,7 +18,7 @@ def test_starting_octave():
     """Check that C major with given octave is correct."""
     scale_notes = musical_scales.scale("D", starting_octave=5)
     names = list(map(lambda note: note.midi, scale_notes))
-    assert names == ["C5", "D5", "E5", "F5", "G5", "A5", "B5", "C6"]
+    assert names == ["D5", "E5", "F#5", "G5", "A5", "B5", "C#6", "D6"]
 
 def test_octaves():
     """Check that D major is correct with 2 octaves."""

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -13,9 +13,9 @@ def test_ionian():
     names = list(map(lambda note: note.midi, scale_notes))
     assert names == ["D3", "E3", "F#3", "G3", "A3", "B3", "C#4", "D4"]
 
-def test_octave():
+def test_starting_octave():
     """Check that C major with given octave is correct."""
-    scale_notes = musical_scales.scale("D", octave=5)
+    scale_notes = musical_scales.scale("D", starting_octave=5)
     names = list(map(lambda note: note.midi, scale_notes))
     assert names == ["C5", "D5", "E5", "F5", "G5", "A5", "B5", "C6"]
 


### PR DESCRIPTION
These commits allow specifying a starting octave. For example:
```python
scale_notes = musical_scales.scale("D", starting_octave=5)
# ["D5", "E5", "F#5", "G5", "A5", "B5", "C#6", "D6"]
```

I have updated the `__init__.py`, the tests, and the readme.