### PR TITLE
Major version: 2.0.0

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,6 +6,6 @@ sphinx:
 
 # Explicitly set the version of Python and its requirements
 python:
-  version: 3.8
+  version: 3.10
   install:
     - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -73,15 +73,38 @@ You can add an integer to a note to raise it by that many semitones:
 ````python
 import musical_scales
 
-D_major_3 = musical_scales.scale("D")
-# Defaults to major scale
+# Notes
+
+# Middle C. If no octave name is provided then defaults to octave 3.
+C3 = musical_scales.Note("C")
+musical_scales.Note("C3")
+
+# Or specify by interval above/below Middle C
+C3 = musical_scales.Note(0)
+C4 = musical_scales.Note(12)
+
+D_sharp = musical_scales.Note(3)
+
+# You can add / subtract integers from notes to shift them
+assert C3 = D_sharp - 3
+
+# Scales
+
+# Defaults to a major scale
+musical_scales.scale("D")
 # [D3, E3, F#3, G3, A3, B3, C#4, D4]
-F_sharp_blues_3 = musical_scales.scale("F#", "blues")
+
+# Or specify a name from musical_scales.scale_intervals.keys()
+musical_scales.scale("F#", "blues")
 # [F#3, A3, B3, C4, C#4, E4, F#4]
-D_major_5 = musical_scales.scale("D", starting_octave=5)
+
+# Specify a starting octave for the note (defaults to 3)
+musical_scales.scale("D5")
 # [D5, E5, F#5, G5, A5, B5, C#6, D6]
-F_sharp_blues_5 = musical_scales.scale("F#", "blues", starting_octave=5)
-# [F#5, A5, B5, C6, C#6, E6, F#6]
+
+# Specify how many octaves to output (keyword required)
+musical_scales.scale("F#", "blues", octaves=2)
+# [F#3, A3, B3, C4, C#4, E4, F#4, A4, B4, C5, C#5, E5, F#5]
 ````
 
 

--- a/README.md
+++ b/README.md
@@ -4,70 +4,74 @@ Retrieve a scale based on a given mode and starting note.
 Information about these scales can be found [on Wikipedia](https://en.wikipedia.org/wiki/List_of_musical_scales_and_modes).
 
 Currently supported scales:
- - acoustic
- - aeolian
- - algerian
- - super locrian
- - augmented
- - bebop dominant
- - blues
- - chromatic
- - dorian
- - double harmonic
- - enigmatic
- - flamenco
- - romani
- - half-diminished
- - harmonic major
- - harmonic minor
- - hijaroshi
- - hungarian minor
- - hungarian major
- - in
- - insen
- - ionian
- - iwato
- - locrian
- - lydian augmented
- - lydian
- - locrian major
- - pentatonic major
- - melodic minor ascending
- - melodic minor descending
- - pentatonic minor
- - mixolydian
- - neapolitan major
- - neapolitan minor
- - octatonic c-d
- - octatonic c-c#
- - persian
- - phrygian dominant
- - phrygian
- - prometheus
- - harmonics
- - tritone
- - two-semitone tritone
- - ukranian dorian
- - whole-tone scale
- - yo
+
+- acoustic
+- aeolian
+- algerian
+- super locrian
+- augmented
+- bebop dominant
+- blues
+- chromatic
+- dorian
+- double harmonic
+- enigmatic
+- flamenco
+- romani
+- half-diminished
+- harmonic major
+- harmonic minor
+- hijaroshi
+- hungarian minor
+- hungarian major
+- in
+- insen
+- ionian
+- iwato
+- locrian
+- lydian augmented
+- lydian
+- locrian major
+- pentatonic major
+- melodic minor ascending
+- melodic minor descending
+- pentatonic minor
+- mixolydian
+- neapolitan major
+- neapolitan minor
+- octatonic c-d
+- octatonic c-c#
+- persian
+- phrygian dominant
+- phrygian
+- prometheus
+- harmonics
+- tritone
+- two-semitone tritone
+- ukranian dorian
+- whole-tone scale
+- yo
+
+## Dependencies
+
+This is Version 2 of the package, which requires Python 3.10 or later (released in 2021). Version 1 supported Python 3.8, and can still be found on PyPI.
 
 ## The Note class
 
 Notes can be specified with either a name or a given number of semitones above middle C (C3).
 Octaves are done MIDI-style, so B2 is immediately followed by C3.
+
 Example notes:
- - `Note("D")` the first D above middle C
- - `Note(2)` two semitones above middle C, which is the same as `Note("D")`.
 
-Notes have two fundamental properties:
- - `.name` e.g. `"C"`
- - `.octave` e.g. `3`
+- `Note("D")` the first D above middle C
+- `Note(2)` two semitones above middle C, which is the same as `Note("D")`.
 
-You can retrieve both together MIDI style with:
- - `.midi` e.g. "F#4"
+Notes have properties inferred from their interval from C.
 
-You can add an integer to a note to raise it by that many semitones:
- - `Note("C") + 12` the first C above middle C
+- `.name` e.g. "D#" (favours sharps)
+- `.enharmonic` e.g. "Eb" (favours flats)
+- `.octave` e.g. 3
+- `.midi` e.g. "F#4" (MIDI representation)
 
 ## Examples
 ````python

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [metadata]
 name = musical-scales
-version = 1.0.1
+version = 2.0.0
+license = MIT
 author = Hector Miller-Bakewell
 author_email = hmillerbakewell@gmail.com
 description = Retrieve a scale based on a given mode and starting note.
@@ -11,7 +12,7 @@ project_urls =
     Bug Tracker = https://github.com/hmillerbakewell/musical-scales
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.10
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
 
@@ -19,7 +20,7 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.8
+python_requires = >=3.10
 
 [options.packages.find]
 where = src

--- a/src/musical_scales/__init__.py
+++ b/src/musical_scales/__init__.py
@@ -36,6 +36,9 @@ def parse_compound_note_name(name: str):
         octave = int(octave)
     return name, octave
 
+def emojify_accidentals(name: str) -> str:
+    """Convert # and b in a note name to their emoji equivalents."""
+    return name.replace("#", "♯").replace("b", "♭")
 
 class Note:
     """A single note in a given octave, e.g. C#3.

--- a/src/musical_scales/__init__.py
+++ b/src/musical_scales/__init__.py
@@ -113,20 +113,19 @@ class Note:
         else:
             return str(self) == str(other)
 
-
-def scale(starting_note, mode="ionian", octaves=1, starting_octave=3):
+def scale(starting_note: Note | str | int, mode="ionian", *, octaves=1):
     """Return a sequence of Notes starting on the given note in the given mode.
 
     Example:
-        * scale("C") # C major (ionian)
+        * scale("C3") # C major (ionian) starting on middle C
         * scale(Note(4), "harmonic minor") # E harmonic minor
     """
     if mode not in scale_intervals:
         raise MusicException(f"The mode {mode} is not available.")
     if not isinstance(starting_note, Note):
-        starting_note = Note(starting_note, starting_octave=starting_octave)
+        starting_note = Note(starting_note)
     notes = [starting_note]
-    for octave in range(0, octaves):
+    for _ in range(0, octaves):
         for interval in scale_intervals[mode]:
             notes.append(notes[-1] + interval)
     return notes

--- a/src/musical_scales/__init__.py
+++ b/src/musical_scales/__init__.py
@@ -10,7 +10,7 @@ class MusicException(Exception):
     pass
 
 
-PATTERN = re.compile(r"^([A-Ga-g])([#b]?)(\d*)$")
+PATTERN = re.compile(r"^([A-Ga-g])([#b]?)(-?\d*)$")
 
 
 def parse_compound_note_name(name: str):
@@ -25,11 +25,11 @@ def parse_compound_note_name(name: str):
     name = name.replace("♯", "#").replace("♭", "b")
     match = PATTERN.match(name)
     if not match:
-        raise MusicException(f"The note name {name} is not valid.")
+        raise MusicException(f"The note name {name} is not valid. Expected forms are like 'C#' or 'C#4'.")
     name = match.group(1) + match.group(2)
     octave = match.group(3)
     if name not in interval_from_names:
-        raise MusicException(f"No note found with name {name}.")
+        raise MusicException(f"No note found with name {name}. Expected A-G with optional # or b.")
     if octave == "":
         octave = 3
     else:

--- a/src/musical_scales/__init__.py
+++ b/src/musical_scales/__init__.py
@@ -59,7 +59,7 @@ class Note:
         if isinstance(name_or_interval, str):
             name, octave = parse_compound_note_name(name_or_interval)
             self.semitones_above_middle_c = interval_from_names[name] + (
-                octave * 12)
+                (octave - 3) * 12)
         elif isinstance(name_or_interval, int):
             self.semitones_above_middle_c = name_or_interval
         else:

--- a/src/musical_scales/__init__.py
+++ b/src/musical_scales/__init__.py
@@ -75,7 +75,9 @@ class Note:
 
     @property
     def name(self):
-        """Get the name of the note."""
+        """Name of the note, e.g. C#. Favours sharps.
+
+        Favours sharps for consistenct, see `enharmonic` for flats."""
         return names_from_interval_favour_sharps[self.semitones_above_middle_c % 12]
 
     @property
@@ -84,9 +86,17 @@ class Note:
         return self.semitones_above_middle_c // 12 + 3
 
     @property
-    def midi(self):
-        """Note name and octave, e.g. C3."""
+    def midi(self) -> str:
+        """Note name and octave, sutiable for MIDI software, e.g. C3.
+
+        Favours sharps.
+        """
         return f"{self.name}{self.octave}"
+
+    @property
+    def enharmonic(self) -> str:
+        """Note name and octave, but favouring flats e.g. Bb."""
+        return names_from_interval_favour_flats[self.semitones_above_middle_c % 12]
 
     def __add__(self, shift: int):
         """Shifting this note's degree upwards."""
@@ -97,11 +107,11 @@ class Note:
         return self + (-shift)
 
     def __eq__(self, other):
-        """Check equality via .midi."""
+        """Check equality via interval, or by midi representation."""
         if isinstance(other, Note):
-            return self.midi == other.midi
+            return self.semitones_above_middle_c == other.semitones_above_middle_c
         else:
-            return self.midi == other or self.name == other
+            return str(self) == str(other)
 
 
 def scale(starting_note, mode="ionian", octaves=1, starting_octave=3):
@@ -177,7 +187,7 @@ scale_intervals = {
 
 scale_intervals["major"] = scale_intervals["ionian"]
 
-names_from_interval = {
+names_from_interval_favour_sharps = {
     0: "C",
     1: "C#",
     2: "D",
@@ -192,6 +202,24 @@ names_from_interval = {
     11: "B"
 }
 """From an interval give the note name, favouring sharps over flats."""
+
+
+names_from_interval_favour_flats = {
+    0: "C",
+    1: "Db",
+    2: "D",
+    3: "Eb",
+    4: "E",
+    5: "F",
+    6: "Gb",
+    7: "G",
+    8: "Ab",
+    9: "A",
+    10: "Bb",
+    11: "B"
+}
+"""From an interval give the note name, favouring sharps over flats."""
+
 
 interval_from_names = {
     "C": 0,

--- a/tests/test_note.py
+++ b/tests/test_note.py
@@ -1,14 +1,35 @@
 """Test the creation of notes."""
 
 import sys
-from pathlib import Path
 sys.path.append('./src')
 
 import musical_scales
-import pytest
+
+def test_regex():
+    parse = musical_scales.parse_compound_note_name
+    assert parse("C") == ("C", 3)
+    assert parse("C3") == ("C", 3)
+    assert parse("C4") == ("C", 4)
+    assert parse("C#") == ("C#", 3)
+    assert parse("C#0") == ("C#", 0)
+    assert parse("Eb-1") == ("Eb", -1)
 
 def test_middle_c():
-    """Test creation of C3."""
+    """Test creation of middle C."""
+    by_name_no_octave = musical_scales.Note("C")
+    by_name_with_octave = musical_scales.Note("C3")
+    by_integer = musical_scales.Note(0)
+    for note in (by_name_no_octave, by_name_with_octave, by_integer):
+        print(note)
+        assert note.octave == 3
+        assert note.name == "C"
+        assert note.semitones_above_middle_c == 0
+        assert str(note) == "C3"
+        assert repr(note) == "C3"
+        assert note.midi == "C3"
+
+def test_interval_shifts():
+    """Test creation of C3 and above."""
     c_3 = musical_scales.Note("C")
     assert c_3.octave == 3
     assert c_3.name == "C"
@@ -16,11 +37,33 @@ def test_middle_c():
     assert d_3.name == "D"
     b_2 = c_3 -1
     assert b_2.name == "B"
-    c_5 = musical_scales.Note("C", starting_octave=5)
-    assert c_5.octave == 5
+
+def test_enharmonic():
+    """Test enharmonic names."""
+    a_sharp = musical_scales.Note("A#3")
+    b_flat = musical_scales.Note("Bb3")
+    assert a_sharp == b_flat
+    assert a_sharp.name == "A#"
+    assert b_flat.name == "A#"
+    assert a_sharp.enharmonic == "Bb"
+    assert b_flat.enharmonic == "Bb"
+
+def note_from_compound_name():
+    """Create notes from compound names."""
+    assert musical_scales.Note("C") == musical_scales.Note("C3")
+    assert musical_scales.Note("C4").semitones_above_middle_c == 12
+    assert musical_scales.Note("D5").semitones_above_middle_c == 26
+    assert musical_scales.Note("A#3").semitones_above_middle_c == 10
+    assert musical_scales.Note("Bb1").semitones_above_middle_c == -14
+
 
 def test_equality():
     """Notes should compare permissively."""
     assert musical_scales.Note("C") == musical_scales.Note("C")
     assert musical_scales.Note("C") == "C3"
-    assert musical_scales.Note("C") == "C"
+
+def test_emojify():
+    """Test conversion of # and b to emoji equivalents."""
+    assert musical_scales.emojify_accidentals("C#") == "C♯"
+    assert musical_scales.emojify_accidentals("Db") == "D♭"
+    assert musical_scales.emojify_accidentals("E") == "E"

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -1,7 +1,6 @@
 """Test the creation of scales."""
 
 import sys
-from pathlib import Path
 sys.path.append('./src')
 
 import musical_scales
@@ -16,7 +15,7 @@ def test_ionian():
 
 def test_starting_octave():
     """Check that C major with given octave is correct."""
-    scale_notes = musical_scales.scale("D", starting_octave=5)
+    scale_notes = musical_scales.scale("D5")
     names = list(map(lambda note: note.midi, scale_notes))
     assert names == ["D5", "E5", "F#5", "G5", "A5", "B5", "C#6", "D6"]
 


### PR DESCRIPTION
Update requirement to Python 3.10 for typing purposes.

Notes can now take in the following example inputs:

```
Note("C")
Note(0)
Note("C3")
```

Which are parsed via regex into name + octave.

Other properties have been updated to have a single-source-of-truth and simplify the data structure.